### PR TITLE
Add min/max values to fan speed command

### DIFF
--- a/src/commands.json
+++ b/src/commands.json
@@ -19,6 +19,7 @@
                 "settable": true,
                 "friendlyName": "speed",
                 "valuePath": [ "ACTUAL" ],
+                "values": [0, 7],
                 "setPath": [ ]
             },
 


### PR DESCRIPTION
Fixes the following crash when setting fan speed:

/haiku2mqtt/node_modules/rxjs/Subscriber.js:243
            throw err;
            ^

TypeError: Cannot read property '0' of undefined
    at Object.number (/haiku2mqtt/node_modules/haiku-senseme/dist/lib/mapValues.js:34:81)
    at validateAndMap (/haiku2mqtt/node_modules/haiku-senseme/dist/lib/mapValues.js:105:34)
    at Object.value.set [as value] (/haiku2mqtt/node_modules/haiku-senseme/dist/lib/walk/accessorVisitor.js:97:60)
    at SafeSubscriber._next (/haiku2mqtt/dist/index.js:95:35)
    at SafeSubscriber.__tryOrUnsub (/haiku2mqtt/node_modules/rxjs/Subscriber.js:239:16)
    at SafeSubscriber.next (/haiku2mqtt/node_modules/rxjs/Subscriber.js:186:22)
    at Subscriber._next (/haiku2mqtt/node_modules/rxjs/Subscriber.js:126:26)
    at Subscriber.next (/haiku2mqtt/node_modules/rxjs/Subscriber.js:90:18)
    at CatchSubscriber.Subscriber._next (/haiku2mqtt/node_modules/rxjs/Subscriber.js:126:26)
    at CatchSubscriber.Subscriber.next (/haiku2mqtt/node_modules/rxjs/Subscriber.js:90:18)